### PR TITLE
Use GIT dependencies for out-of-repository crates instead of paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["player","rust-av","sdl2"]
 [dependencies]
 clap = "2.24.1"
 sdl2 = "0.31"
-av-data = { version = "0.1.0", path = "../rust-av/data" }
-av-codec = { version = "0.1.0", path = "../rust-av/codec" }
-av-format = { version = "0.1.0", path = "../rust-av/format" }
-libvpx = { version = "0.1.0", path = "../vpx-rs", features=["codec-trait"] }
-libopus = { version = "0.1.0", path = "../opus-rs", features=["codec-trait"] }
-matroska = { version = "0.1.0", path = "../matroska" }
-av-vorbis = { path = "../av-vorbis" }
+av-data = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
+av-codec = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
+av-format = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
+libvpx = { version = "0.1.0", git = "https://github.com/rust-av/vpx-rs", features = ["codec-trait"] }
+libopus = { version = "0.1.0", git = "https://github.com/rust-av/opus-rs", features = ["codec-trait"] }
+matroska = { version = "0.1.0", git = "https://github.com/rust-av/matroska" }
+av-vorbis = { git = "https://github.com/rust-av/av-vorbis" }


### PR DESCRIPTION
https://github.com/rust-av/rust-av/issues/55